### PR TITLE
Refactoring OCDSpecExpectation and custom matchers

### DIFF
--- a/OCDSpec.xcodeproj/project.pbxproj
+++ b/OCDSpec.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		C01FCF5008A95454005424AE /* InvalidClass.m in Sources */ = {isa = PBXBuildFile; fileRef = C01FCF5008A95454005424A9 /* InvalidClass.m */; };
 		C01FCF5008A95454005424B1 /* MultipleMatchingClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = C01FCF5008A95454005424B0 /* MultipleMatchingClasses.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		C01FCF5008A95454005424B5 /* MultipleMatchingClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = C01FCF5008A95454005424B0 /* MultipleMatchingClasses.m */; };
+		F8E1ABEA1566F50700D8DAAB /* OCDSpecExpectation+CustomMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = F8E1ABE91566F50700D8DAAB /* OCDSpecExpectation+CustomMatcher.m */; };
+		F8E1ABED1566F58A00D8DAAB /* OCDCustomMatcherSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = F8E1ABEC1566F58A00D8DAAB /* OCDCustomMatcherSpec.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -133,6 +135,9 @@
 		C01FCF5008A95454005424AF /* InvalidClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InvalidClass.h; path = Helpers/InvalidClass.h; sourceTree = "<group>"; };
 		C01FCF5008A95454005424B0 /* MultipleMatchingClasses.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MultipleMatchingClasses.m; path = Helpers/MultipleMatchingClasses.m; sourceTree = "<group>"; };
 		C01FCF5008A95454005424B6 /* MultipleMatchingClasses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MultipleMatchingClasses.h; path = Helpers/MultipleMatchingClasses.h; sourceTree = "<group>"; };
+		F8E1ABE81566F50700D8DAAB /* OCDSpecExpectation+CustomMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OCDSpecExpectation+CustomMatcher.h"; sourceTree = "<group>"; };
+		F8E1ABE91566F50700D8DAAB /* OCDSpecExpectation+CustomMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "OCDSpecExpectation+CustomMatcher.m"; sourceTree = "<group>"; };
+		F8E1ABEC1566F58A00D8DAAB /* OCDCustomMatcherSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCDCustomMatcherSpec.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,6 +166,8 @@
 				07C2DDF4128442EA009E03F7 /* MockExample.m */,
 				07C3DBA913622CE600CADEDB /* MockObjectWithEquals.h */,
 				07C3DBAA13622CE600CADEDB /* MockObjectWithEquals.m */,
+				F8E1ABE81566F50700D8DAAB /* OCDSpecExpectation+CustomMatcher.h */,
+				F8E1ABE91566F50700D8DAAB /* OCDSpecExpectation+CustomMatcher.m */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -214,6 +221,7 @@
 				0761B5231359E48C00FE98CC /* OCDSpecExpectationSpec.m */,
 				073A6F9312F1D43C003EC052 /* Mocks */,
 				073A6FCC12F1D7DF003EC052 /* Programs */,
+				F8E1ABEC1566F58A00D8DAAB /* OCDCustomMatcherSpec.m */,
 			);
 			path = Specs;
 			sourceTree = "<group>";
@@ -458,6 +466,8 @@
 				C01FCF5008A95454005424A3 /* ValidClass.m in Sources */,
 				C01FCF5008A95454005424AA /* InvalidClass.m in Sources */,
 				C01FCF5008A95454005424B1 /* MultipleMatchingClasses.m in Sources */,
+				F8E1ABEA1566F50700D8DAAB /* OCDSpecExpectation+CustomMatcher.m in Sources */,
+				F8E1ABED1566F58A00D8DAAB /* OCDCustomMatcherSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OCDSpec/OCDSpecExpectation.h
+++ b/OCDSpec/OCDSpecExpectation.h
@@ -15,6 +15,8 @@
 -(void) toBeFalse;
 -(void) toExist;
 
+-(void) failWithMessage:(NSString *)message;
+
 @end
 
 #define expect(obj)       [[OCDSpecExpectation alloc] initWithObject:obj inFile:[NSString stringWithUTF8String:__FILE__] atLineNumber:__LINE__]

--- a/OCDSpec/OCDSpecExpectation.m
+++ b/OCDSpec/OCDSpecExpectation.m
@@ -35,22 +35,26 @@
 -(void) toBeTrue
 {
     if (![actualObject boolValue])
-        [OCDSpecFail fail:[NSString stringWithFormat:@"%b was expected to be true, but was false", actualObject] atLine:line inFile:file];
+        [self failWithMessage:[NSString stringWithFormat:@"%b was expected to be true, but was false", actualObject]];
 }
 
 -(void) toBeFalse
 {
     if ([actualObject boolValue]) {
-        [OCDSpecFail fail:[NSString stringWithFormat:@"%b was expected to be false, but was true", actualObject] atLine:line inFile:file];
-    }
+        [self failWithMessage:[NSString stringWithFormat:@"%b was expected to be false, but was true", actualObject]];    }
 }
 
 -(void) toExist
 {
     if (!actualObject)
-        [OCDSpecFail fail:@"Object was expected to exist, but didn't"
-                   atLine: line
-                   inFile: file];
+        [self failWithMessage: @"Object was expected to exist, but didn't"];
+}
+
+-(void) failWithMessage:(NSString *)message
+{
+    [OCDSpecFail fail: message
+               atLine: line
+               inFile: file];
 }
 
 -(void) fail:(NSString *)errorFormat with:(id)expectedObject

--- a/Specs/Mocks/OCDSpecExpectation+CustomMatcher.h
+++ b/Specs/Mocks/OCDSpecExpectation+CustomMatcher.h
@@ -1,0 +1,7 @@
+#import "OCDSpecExpectation.h"
+
+@interface OCDSpecExpectation (CustomMatcher)
+
+-(void) toEqualABC;
+
+@end

--- a/Specs/Mocks/OCDSpecExpectation+CustomMatcher.m
+++ b/Specs/Mocks/OCDSpecExpectation+CustomMatcher.m
@@ -1,0 +1,11 @@
+#import "OCDSpecExpectation+CustomMatcher.h"
+
+@implementation OCDSpecExpectation (CustomMatcher)
+
+-(void) toEqualABC
+{
+  if (actualObject != @"ABC")
+    [self failWithMessage: [NSString stringWithFormat: @"Expected ABC, but got %@", actualObject]];
+}
+
+@end

--- a/Specs/OCDCustomMatcherSpec.m
+++ b/Specs/OCDCustomMatcherSpec.m
@@ -1,0 +1,24 @@
+#import "OCDSpec/OCDSpec.h"
+#import "OCDSpecExpectation+CustomMatcher.h"
+
+CONTEXT(OCDSpecExpectation_CustomMatcherSpec)
+{
+    describe(@"toEqualABC",
+             it(@"fails when the object is not ABC",
+                ^{
+                    @try
+                    {
+                        [expect(@"123") toEqualABC];
+                        FAIL(@"Code did not throw a failure exception");
+                    }
+                    @catch (NSException *exception)
+                    {
+                        [expect([exception reason]) toBeEqualTo: @"Expected ABC, but got 123"];
+                    }
+                }),
+             it(@"passes when the object is ABC",
+                ^{
+                    [expect(@"ABC") toEqualABC];
+                }),
+             nil);
+}

--- a/Specs/OCDSpecExpectationSpec.m
+++ b/Specs/OCDSpecExpectationSpec.m
@@ -36,6 +36,32 @@ CONTEXT(OCDSpecExpectation){
             [expect(expectation.file) toBeEqualTo:[NSString stringWithUTF8String:__FILE__]];
           }),
           nil);
+    
+  describe(@"failWithMessage",
+           it(@"includes the line and file",
+              ^{
+                  OCDSpecExpectation *expectation = [[OCDSpecExpectation alloc] initWithObject:actualObject inFile:@"FILENAME" atLineNumber:456];
+                  @try {
+                      [expectation failWithMessage: @"Some Message"];
+                      FAIL(@"Code did not throw a failure exception");
+                  }
+                  @catch (NSException *exception) {
+                      [expect([[exception userInfo] objectForKey:@"file"]) toBeEqualTo:@"FILENAME"];
+                      [expect([[exception userInfo] objectForKey:@"line"]) toBeEqualTo:[NSNumber numberWithLong:456]];
+                  }              
+              }),
+           it(@"includes the message",
+              ^{
+                  OCDSpecExpectation *expectation = [[OCDSpecExpectation alloc] initWithObject:actualObject inFile:@"FILENAME" atLineNumber:456];
+                  @try {
+                      [expectation failWithMessage: @"Some Message"];
+                      FAIL(@"Code did not throw a failure exception");
+                  }
+                  @catch (NSException *exception) {
+                      [expect([exception reason]) toBeEqualTo: @"Some Message"];
+                  }              
+              }),
+           nil);
 
   describe(@"toBeEqualTo",
           it(@"passes when two objects are equal", ^{


### PR DESCRIPTION
I ended up in merge hell, so I made a new branch and put my changes in here.  There were four commits, but now there are two.  The first one was made irrelevant because of changes you made, and the last change I was having trouble re-implementing.  Here are the middle two, with the added specs for failWithMessage.
