### PR TITLE
Fix exit code of mac specs and small typo fix

### DIFF
--- a/OCDSpec/Programs/macMain.m
+++ b/OCDSpec/Programs/macMain.m
@@ -4,11 +4,14 @@
 int main(int argc, const char *argv[]) {
   OCDSpecSuiteRunner *runner = [[OCDSpecSuiteRunner alloc] init];
 
+  int failures;
+
   @autoreleasepool
   {
     [runner runAllDescriptions];
+    failures = [runner failures];
   }
 
-  return 0;
+  return failures;
 }
 

--- a/Specs/OCDSpecSuiteRunnerSpec.m
+++ b/Specs/OCDSpecSuiteRunnerSpec.m
@@ -44,7 +44,7 @@ CONTEXT(OCDSpecSuiteRunner){
             [expect([NSNumber numberWithInt: runner.failures]) toBeEqualTo:[NSNumber numberWithInt: 2]];
           }),
 
-          it(@"totals the results` from multiple classes", ^{
+          it(@"totals the results from multiple classes", ^{
             runner.baseClass = [MultipleMatchingClasses class];
 
             [FirstMultipleClass setSuccesses: 1 andFailures:3];


### PR DESCRIPTION
Before, both xcodebuild and running the built product always had an exit code of 0.

Now, the exit code of the xcodebuild command is 65 for spec failures and 0 when successful. (There may be other significant codes, but I can't change this.)

To get the exit code corresponding to the number of failing tests, you have to run the built product.

```
$ ./build/Debug/TestMacVersion 
/Users/eric/Projects/8thlight/OCDSpec/Specs/OCDSpecOutputter+RedirectOutputSpec.m:20: error: The Test data was not redirected
Tests ran with 46 passing tests and 1 failing tests

$ echo $?
1
```
